### PR TITLE
fixup(GH.Actions): Replace Multiline character in conditional

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,9 +68,9 @@ jobs:
             top-commit.txt
 
   release:
-    if: >
-      ${{ github.ref == 'refs/heads/timberland_1.0_final' &&
-          github.event_name == 'push' }}
+    if: |
+          github.ref == 'refs/heads/timberland_1.0_final' &&
+          github.event_name == 'push'
     needs: build
     runs-on: ubuntu-22.04
     permissions:


### PR DESCRIPTION
Appears that we should have been using a pipe for the multiline conditional rather than the folding character, and there is reports [1] that the pipe and the expression indicator may have some conflicts in if conditionals.  However if always evaluates with the expression anyways [2].  The result was the "deploy" step was erroneously running on non-`timberland_1.0_final` branches.

[1] - https://github.com/orgs/community/discussions/25641
[2] - https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif