### PR TITLE
Populate NBFT table for failure cases.

### DIFF
--- a/NetworkPkg/NvmeOfDxe/NvmeOfDriver.h
+++ b/NetworkPkg/NvmeOfDxe/NvmeOfDriver.h
@@ -298,6 +298,8 @@ typedef struct _NVMEOF_NBFT {
   BOOLEAN                       IsDiscoveryNqn;
   NVMEOF_DEVICE_PRIVATE_DATA    *Device;
   NVMEOF_ATTEMPT_CONFIG_NVDATA  *AttemptData;
+  struct spdk_nvme_transport_id *FailTridInfo;
+  BOOLEAN                       IsFailed;
 } NVMEOF_NBFT;
 extern NVMEOF_NBFT gNvmeOfNbftList[];
 extern UINT8 gNvmeOfNbftListIndex;

--- a/NetworkPkg/NvmeOfDxe/NvmeOfNbft.c
+++ b/NetworkPkg/NvmeOfDxe/NvmeOfNbft.c
@@ -593,6 +593,80 @@ NvmeOfFillSubsystemNamespaceSection (
 
   // Iterate on each namespace and populate the details.
   for (Index = 0; Index < gNvmeOfNbftListIndex; Index++) {
+    //
+    // Fill the Subsystem Namespace section.
+    //
+    SubsystemNamespace->StructureId                    = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_NAMESPACE_DESCRIPTOR_ID;
+    Control->SubSystemVersion                          = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_VERSION;
+    Control->SubSystemDescLength                       = (UINT16) sizeof (EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_NAMESPACE_DESCRIPTOR);
+    SubsystemNamespace->Index                          = (UINT16)DeviceIndex + 1;
+    SubsystemNamespace->Flags                         |= EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_FLAG_BLOCK_VALID;
+    SubsystemNamespace->SubsystemTransportAdressLength = sizeof (EFI_IPv6_ADDRESS);
+    SubsystemNamespace->HfiAssociationLen              = sizeof (UINT8);
+
+    //SsnsExtInfo section
+    SsnsExtInfo.StructureId                            = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_NAMESPACE_INFO_EXT_DESCRIPTOR_ID;
+    SsnsExtInfo.Version                                = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_EXT_INFO_DESCRIPTOR_VERSION;
+    SsnsExtInfo.SsnsIndex                              = Index + 1;
+    SsnsExtInfo.Flags                                  = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_EXT_INFO_DESCRIPTOR_VERSION_FLAG_STRUCTURE_VALID;
+    SubsystemNamespace->Flags                         |= EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_FLAG_USE_SSNS_EXT_INFO;
+    SubsystemNamespace->SsnsExtendedInfoLength         = sizeof (EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_EXT_INFO_DESCRIPTOR);
+
+    // Transport type
+    SubsystemNamespace->TransportType = NVMEOF_TRANSPORT_TCP;
+    if (gNvmeOfNbftList[Index].IsDiscoveryNqn) {
+      SubsystemNamespace->PrimaryDiscoveryCtrlrIndex = gNvmeOfNbftList[Index].DeviceAdapterIndex;
+      // Update flag
+      SubsystemNamespace->Flags |= EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_FLAG_DISCOVERED_NAMESPACE;
+    }
+
+    // Root Path in heap
+    if (gNvmeOfRootPath != NULL) {
+      SsnsExtInfo.DhcpRootPathLength = (AsciiStrLen (gNvmeOfRootPath) - 1);
+    } else {
+      SsnsExtInfo.DhcpRootPathLength = 0;
+    }
+
+    // For failed connection
+    if (gNvmeOfNbftList[Index].IsFailed == TRUE) {
+      SubsystemNamespace->Flags |= EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_FLAG_UNAVAILABLE_NAMESPACE_1;
+      // Transport address
+      if ((gNvmeOfNbftList[Index].AttemptData->SubsysConfigData.NvmeofIpMode == IP_MODE_IP4) ||
+        (gNvmeOfNbftList[Index].AttemptData->AutoConfigureMode == IP_MODE_AUTOCONFIG_IP4)) {
+        EFI_IPv4_ADDRESS  v4;
+        NetLibAsciiStrToIp4 (gNvmeOfNbftList[Index].FailTridInfo->traddr, &v4);
+        NvmeOfMapV4ToV6Addr (&v4, &SubsytemTrasportAddress);
+        NvmeOfAddHeapItem(Heap, &SubsytemTrasportAddress, sizeof (EFI_IPv6_ADDRESS));
+      } else if ((gNvmeOfNbftList[Index].AttemptData->SubsysConfigData.NvmeofIpMode == IP_MODE_IP6) ||
+          (gNvmeOfNbftList[Index].AttemptData->AutoConfigureMode == IP_MODE_AUTOCONFIG_IP6)) {
+        NetLibAsciiStrToIp6 (gNvmeOfNbftList[Index].FailTridInfo->traddr,
+          &SubsytemTrasportAddress);
+        NvmeOfAddHeapItem (Heap, &SubsytemTrasportAddress, sizeof (EFI_IPv6_ADDRESS));
+      } else {
+        ASSERT (FALSE);
+      }
+      // Transport port
+      Len = AsciiStrLen (gNvmeOfNbftList[Index].FailTridInfo->trsvcid);
+      SubsystemNamespace->SubsystemTransportServiceIdLength = Len;
+      NvmeOfAddHeapItem (Heap, gNvmeOfNbftList[Index].FailTridInfo->trsvcid, Len);
+      SubsystemNamespace->PrimaryHfiDescriptorIndex = HfiHeader->Index;
+      // HFI association
+      NvmeOfAddHeapItem (Heap, &(gNvmeOfNbftList[Index].DeviceAdapterIndex), sizeof(UINT8));
+      // Fill the subsystem NQN into the heap.
+      Len = (UINT16)AsciiStrLen (gNvmeOfNbftList[Index].FailTridInfo->subnqn);
+      NvmeOfAddHeapItem (Heap, gNvmeOfNbftList[Index].FailTridInfo->subnqn, Len);
+      SubsystemNamespace->SubsystemNamespaceNqnLen = Len;
+      // Copy SsnsExtInfo  to heap and update the SubSystem Namespace header structure
+      NvmeOfAddHeapItem (Heap, &SsnsExtInfo, sizeof (EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_EXT_INFO_DESCRIPTOR));
+      if (SsnsExtInfo.DhcpRootPathLength > 0) {
+        NvmeOfAddHeapItem (Heap, gNvmeOfRootPath, SsnsExtInfo.DhcpRootPathLength);
+      }
+      // Advance the subsystem namespace section
+      SubsystemNamespace = (EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_NAMESPACE_DESCRIPTOR *)((UINTN)SubsystemNamespace +
+         NBFT_ROUNDUP(sizeof (EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_NAMESPACE_DESCRIPTOR)));
+      DeviceIndex++;
+      continue;
+    }
     // Logic to skip already processed namespace by comparing NID
     AlreadyProcessed = FALSE;
     NET_LIST_FOR_EACH_SAFE (ProcessedEntry, NextEntryProcessed, &gProcessedNamespaceList.Link) {
@@ -607,25 +681,8 @@ NvmeOfFillSubsystemNamespaceSection (
       SubsystemNamespace->HfiAssociationLen += sizeof (UINT8);
       continue;
     }
-    //
-    // Fill the Subsystem Namespace section.
-    //
-    SubsystemNamespace->StructureId  = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_NAMESPACE_DESCRIPTOR_ID;
-    Control->SubSystemVersion        = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_VERSION;
-    Control->SubSystemDescLength     = (UINT16) sizeof (EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_NAMESPACE_DESCRIPTOR);
-    SubsystemNamespace->Index        = (UINT16) DeviceIndex + 1;
-    SubsystemNamespace->Flags        = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_FLAG_BLOCK_VALID;
-    // Transport type
-    SubsystemNamespace->TransportType = NVMEOF_TRANSPORT_TCP;
-
-    if (gNvmeOfNbftList[Index].IsDiscoveryNqn) {
-      SubsystemNamespace->PrimaryDiscoveryCtrlrIndex = gNvmeOfNbftList[Index].DeviceAdapterIndex;
-      // Update flag
-      SubsystemNamespace->Flags |= EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_FLAG_DISCOVERED_NAMESPACE;
-    }
 
     // Transport address
-    SubsystemNamespace->SubsystemTransportAdressLength = sizeof(EFI_IPv6_ADDRESS);
     if ((gNvmeOfNbftList[Index].AttemptData->SubsysConfigData.NvmeofIpMode == IP_MODE_IP4) ||
       (gNvmeOfNbftList[Index].AttemptData->AutoConfigureMode == IP_MODE_AUTOCONFIG_IP4)) {
       EFI_IPv4_ADDRESS  v4;
@@ -665,10 +722,6 @@ NvmeOfFillSubsystemNamespaceSection (
     NvmeOfAddHeapItem (Heap, gNvmeOfNbftList[Index].Device->NameSpace->ctrlr->trid.subnqn, Len);
     SubsystemNamespace->SubsystemNamespaceNqnLen = Len;
 
-    SsnsExtInfo.StructureId      = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_NAMESPACE_INFO_EXT_DESCRIPTOR_ID;
-    SsnsExtInfo.Version          = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_EXT_INFO_DESCRIPTOR_VERSION;
-    SsnsExtInfo.SsnsIndex        = Index + 1;
-    SsnsExtInfo.Flags            = EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_EXT_INFO_DESCRIPTOR_VERSION_FLAG_STRUCTURE_VALID;
     // Controller ID
     SsnsExtInfo.ControllerId = gNvmeOfNbftList[Index].Device->NameSpace->ctrlr->cntlid;
     if (gNvmeOfNbftList[Index].IsDiscoveryNqn) {
@@ -677,19 +730,11 @@ NvmeOfFillSubsystemNamespaceSection (
     } else {
       SsnsExtInfo.Asqsz = DEFAULT_ADMIN_QUEUE_SIZE;
     }
-    // Root Path in heap
-    if (gNvmeOfRootPath != NULL) {
-      SsnsExtInfo.DhcpRootPathLength = (AsciiStrLen(gNvmeOfRootPath) - 1);
-    } else {
-      SsnsExtInfo.DhcpRootPathLength = 0;
-    }
     // Copy SsnsExtInfo  to heap and update the SubSystem Namespace header structure
     NvmeOfAddHeapItem (Heap, &SsnsExtInfo, sizeof (EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_EXT_INFO_DESCRIPTOR));
-    SubsystemNamespace->SsnsExtendedInfoLength = sizeof (EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_EXT_INFO_DESCRIPTOR);
     if (SsnsExtInfo.DhcpRootPathLength > 0) {
       NvmeOfAddHeapItem (Heap, gNvmeOfRootPath, SsnsExtInfo.DhcpRootPathLength);
     }
-    SubsystemNamespace->Flags |=  EFI_ACPI_NVMEOF_BFT_SUBSYSTEM_DESCRIPTOR_FLAG_USE_SSNS_EXT_INFO;
 
     // Add an entry to processed namespace list
     ProcessedNamespace = AllocateZeroPool (sizeof (NVMEOF_PROCESSED_NAMESPACE));

--- a/NetworkPkg/NvmeOfDxe/NvmeOfSpdk.c
+++ b/NetworkPkg/NvmeOfDxe/NvmeOfSpdk.c
@@ -374,6 +374,35 @@ NvmeOfAttachCallback (
 }
 
 /**
+  Function to insert failed connection info in NBFT list.
+
+  @param[in]  NVMEOF_ATTEMPT_CONFIG_NVDATA   Attempt data
+  @param[in]  struct spdk_nvme_transport_id  Trid Info
+  @param[in]  BOOLEAN                        Flag indicating memory allocation \
+                                             required for IO/Discovery subsystem
+  @retval NONE                               VOID
+**/
+VOID
+InsertFailNodeNbft (
+  IN NVMEOF_ATTEMPT_CONFIG_NVDATA   *AttemptConfigData,
+  IN struct spdk_nvme_transport_id  *Trid,
+  IN BOOLEAN                        AllocReq
+  )
+{
+  if (AllocReq) {
+    gNvmeOfNbftList[gNvmeOfNbftListIndex].FailTridInfo = AllocateZeroPool (sizeof (struct spdk_nvme_transport_id));
+    if (gNvmeOfNbftList[gNvmeOfNbftListIndex].FailTridInfo == NULL) {
+      DEBUG ((DEBUG_ERROR, "Memory allocation to FailTridInfo failed\n"));
+    }
+    CopyMem (gNvmeOfNbftList[gNvmeOfNbftListIndex].FailTridInfo, Trid, sizeof (struct spdk_nvme_transport_id));
+  } else {
+    gNvmeOfNbftList[gNvmeOfNbftListIndex].FailTridInfo = Trid;
+  }
+  gNvmeOfNbftList[gNvmeOfNbftListIndex].AttemptData = AttemptConfigData;
+  gNvmeOfNbftList[gNvmeOfNbftListIndex].IsFailed = TRUE;
+}
+
+/**
   Populates transport data and calls SPDK probe
 
   @param  NVMEOF_DRIVER_DATA             Driver Private context.
@@ -398,6 +427,9 @@ NvmeOfProbeControllers (
   struct spdk_nvme_transport_id *Trid;
   struct spdk_nvme_ctrlr        *Ctrlr  = NULL;
   struct spdk_nvme_ctrlr_opts   Opts = {0, };
+  struct spdk_nvme_fail_trid    *FailedTridInfo;
+  LIST_ENTRY                    *Entry;
+  LIST_ENTRY                    *NextEntry;
 
   Trid = AllocateZeroPool (sizeof (struct spdk_nvme_transport_id));
   if (Trid == NULL) {
@@ -447,6 +479,9 @@ NvmeOfProbeControllers (
   if (spdk_nvme_probe (Trid, Private, NvmeOfProbeCallback,
                          NvmeOfAttachCallback, NULL) != 0) {
     DEBUG ((EFI_D_ERROR, "spdk_nvme_probe() failed for  %a\n", Trid->traddr));
+    // Filling attempt data for connecion failure case for IO & Discovery controller
+    InsertFailNodeNbft(AttemptConfigData, Trid, TRUE);
+    gNvmeOfNbftListIndex++;
     FreePool (Trid);
     return EFI_NOT_FOUND;
   } else {
@@ -464,6 +499,13 @@ NvmeOfProbeControllers (
       if (Ctrlr) {
         NVMeOfGetAsqz (Ctrlr);
         nvme_transport_ctrlr_destruct (Ctrlr);
+      }
+      // Failed discovered subsystem info for NBFT
+      NET_LIST_FOR_EACH_SAFE (Entry, NextEntry, &fail_conn) {
+        FailedTridInfo = NET_LIST_USER_STRUCT (Entry, struct spdk_nvme_fail_trid, link);
+        InsertFailNodeNbft (AttemptConfigData, &FailedTridInfo->trid, FALSE);
+        RemoveEntryList (Entry);
+        FreePool (FailedTridInfo);
       }
     }
   }
@@ -625,6 +667,9 @@ NVMeOfGetAsqz (
     struct spdk_nvmf_discovery_log_page_entry *Entry = &gDiscoveryPage->entries[DCntr];
      
     for (NCntr = 0; NCntr < gNvmeOfNbftListIndex; NCntr++) {
+      if (gNvmeOfNbftList[NCntr].IsFailed == TRUE) {
+        continue;
+       }
       IsDiscovery = gNvmeOfNbftList[NCntr].Device->Controller->IsDiscoveryNqn;
       TrAddress = gNvmeOfNbftList[NCntr].Device->NameSpace->ctrlr->trid.traddr;
 


### PR DESCRIPTION
This change is to populate the details of failed connections to NBFT. This applies to such subsystems, for which attempt has been configured but the NVMe-oF driver was unable to create a successful connection to them. This change will enable the booting OS to get the details of such subsystems from NBFT and retry the connection to proceed with booting from them.