### PR TITLE
Build and package VConfig.efi

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,7 @@ jobs:
           sha256sum -b Build/OvmfX64/DEBUG_GCC5/FV/OVMF_CODE.fd \
               Build/OvmfX64/DEBUG_GCC5/FV/OVMF_VARS.fd \
               Build/OvmfX64/DEBUG_GCC5/X64/NvmeOfCli.efi \
+              Build/OvmfX64/DEBUG_GCC5/X64/VConfig.efi \
               > checksum.sha256
           EOF
       - name: update
@@ -59,6 +60,7 @@ jobs:
           Build/OvmfX64/DEBUG_GCC5/FV/OVMF_CODE.fd
           Build/OvmfX64/DEBUG_GCC5/FV/OVMF_VARS.fd
           Build/OvmfX64/DEBUG_GCC5/X64/NvmeOfCli.efi
+          Build/OvmfX64/DEBUG_GCC5/X64/VConfig.efi
       - name: store artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/NetworkPkg/NetworkComponents.dsc.inc
+++ b/NetworkPkg/NetworkComponents.dsc.inc
@@ -21,6 +21,7 @@
 
   !if $(NETWORK_VLAN_ENABLE) == TRUE
     NetworkPkg/VlanConfigDxe/VlanConfigDxe.inf
+    NetworkPkg/Application/VConfig/VConfig.inf
   !endif
 
   NetworkPkg/MnpDxe/MnpDxe.inf


### PR DESCRIPTION
`VConfig.efi` is necessary to set up configurations with 802.1q VLANs in the PoC. It is the only binary I still have to ship in the SUSE Linux PoC repo, as all else can be downloaded from public repositories. I would like to get rid of all binaries there, but that requires that I obtain `VConfig.efi` from somewhere else.

This PR modifies the sources to build and package `VConfig.efi`. No actual C code is modified.