### PR TITLE
NetworkPkg/NvmeOfDxe: Resolve NBFT population issues

### DIFF
--- a/NetworkPkg/NvmeOfDxe/NvmeOfDriver.h
+++ b/NetworkPkg/NvmeOfDxe/NvmeOfDriver.h
@@ -2,7 +2,7 @@
   NvmeOfDxe driver is used to manage non-volatile memory subsystem which follows
   NVM Express Over Fabric TCP specification.
 
-  Copyright (c) 2021 - 2023, Dell Inc. or its subsidiaries. All Rights Reserved.<BR>
+  Copyright (c) 2021 - 2024, Dell Inc. or its subsidiaries. All Rights Reserved.<BR>
   Copyright (c) 2022 - 2023, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -293,7 +293,8 @@ extern NVMEOF_NQN_NID  gNvmeOfNqnNidMap[];
 extern UINT8           NqnNidMapINdex;
 
 typedef struct _NVMEOF_NBFT {
-  UINT8                            DeviceAdapterIndex;
+  UINT8                            PrimaryHfiIndex;
+  UINT8                            PrimaryDiscoveryCtlrIndex;
   BOOLEAN                          IsDiscoveryNqn;
   NVMEOF_DEVICE_PRIVATE_DATA       *Device;
   NVMEOF_ATTEMPT_CONFIG_NVDATA     *AttemptData;

--- a/NetworkPkg/NvmeOfDxe/NvmeOfNbft.h
+++ b/NetworkPkg/NvmeOfDxe/NvmeOfNbft.h
@@ -1,7 +1,7 @@
 /** @file
   Function definitions for nBFT.
 
-  Copyright (c) 2021 - 2023, Dell Inc. or its subsidiaries. All Rights Reserved.<BR>
+  Copyright (c) 2021 - 2024, Dell Inc. or its subsidiaries. All Rights Reserved.<BR>
   Copyright (c) 2022, Intel Corporation. All rights reserved.<BR>
   SPDX-License-Identifier: BSD-2-Clause-Patent
 
@@ -35,7 +35,8 @@ typedef struct {
   CHAR8                                        MacString[NVMEOF_MAX_MAC_STRING_LEN];
   BOOLEAN                                      HostOverrideEnable;
   EFI_ACPI_NVMEOF_BFT_HFI_HEADER_DESCRIPTOR    *HfiHeaderRef;
-} NVMEOF_PROCESSED_MAC;
+  UINTN                                        HfiTrDescriptorHash;
+} NVMEOF_PROCESSED_HFI;
 
 typedef struct {
   LIST_ENTRY    Link;
@@ -50,6 +51,7 @@ typedef struct {
 
 typedef struct {
   UINT8             AdapterIndex;
+  UINT8             PrimaryHfiIndex;
   BOOLEAN           Ipv6Flag;
   UINT8             SecurityProfileIndex;
   UINT16            Port;


### PR DESCRIPTION
- Adjust HFI population logic to no longer skip by MAC, instead check for a unique transport descriptor hash
- Discovery ctlr population logic no longer treats each DeviceAdapter as an individual Discovery ctlr; Discovery ctlr entries now populated based on order in which unique Disc. ctlrs were found
- Properly map SSNS, Discovery ctlrs to their respective primary HFI
- Properly map SSNS records to their respective primary Discovery ctlr

Fixes #33