### PR TITLE
GitHub workflows: build.yaml: update download-artifact@v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
       TAG: ${{ needs.build.outputs.tag }}
     steps:
       - name: download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
       - name: create release notes
         run: |
           cat >relnotes.txt <<EOF


### PR DESCRIPTION
The "release" part of the workflow [fails](https://github.com/timberland-sig/edk2/actions/runs/17408082232) in timberland_1.0_final because of the deprecated action.